### PR TITLE
Resolve Issue #5: customizable global properties

### DIFF
--- a/anodot-reporter-example/src/main/java/com/kenshoo/metrics/anodot/example/AnodotReporterFactoryExample.java
+++ b/anodot-reporter-example/src/main/java/com/kenshoo/metrics/anodot/example/AnodotReporterFactoryExample.java
@@ -1,10 +1,7 @@
 package com.kenshoo.metrics.anodot.example;
 
 import com.codahale.metrics.MetricRegistry;
-import com.kenshoo.metrics.anodot.AnodotGlobalProperties;
-import com.kenshoo.metrics.anodot.AnodotReporterConfiguration;
-import com.kenshoo.metrics.anodot.AnodotReporterWrapper;
-import com.kenshoo.metrics.anodot.DefaultAnodotReporterConfiguration;
+import com.kenshoo.metrics.anodot.*;
 import com.kenshoo.metrics.anodot.metrics3.Anodot3ReporterFactory;
 
 /**
@@ -16,17 +13,22 @@ import com.kenshoo.metrics.anodot.metrics3.Anodot3ReporterFactory;
 public class AnodotReporterFactoryExample {
 
     public static void main(String[] args) {
-        // We assume your app has an active MetricRegistry (e.g. within a Dropwizard app)
+        // We assume our app has an active MetricRegistry (e.g. within a Dropwizard app)
         final MetricRegistry metricRegistry = new MetricRegistry();
 
         // It might already contain some metrics:
         metricRegistry.counter("some.counter").inc();
 
-        // Create AnodotGlobalProperties object with your global properties;
-        // These properties will be added to each reported metric - so in Anodot you'll be able to slice by version / build / server
+        // Create an AnodotGlobalProperties object with your global properties;
+        // These properties will be added to each reported metric
+        //
+        // You can use the supplied DefaultAnodotGlobalProperties which adds version / build / server properties
         // Overloads for constructor with fewer arguments exist -
         // For example, if you want the server name to be inferred automatically
-        final AnodotGlobalProperties globalProperties = new AnodotGlobalProperties(
+        //
+        // Alternatively, you can create your own implementation of AnodotGlobalProperties with the properties of your choice,
+        // or use the EmptyAnodotGlobalProperties if you wish no global properties to be added
+        final AnodotGlobalProperties globalProperties = new DefaultAnodotGlobalProperties(
                 /* version */ "1.0.1",
                 /* build   */ "b2232",
                 /* server  */ "server1.prod");
@@ -38,11 +40,11 @@ public class AnodotReporterFactoryExample {
                 /* Anodot URI */ "https://api.anodot.com/api/v1/metrics");
 
         // Create the reporter factory based on the given configuration.
-        final Anodot3ReporterFactory reporterFactory = new Anodot3ReporterFactory(anodotConf);
+        final Anodot3ReporterFactory reporterFactory = new Anodot3ReporterFactory(anodotConf, globalProperties);
 
         // Create the reporter "wrapper" which provides a simple API for starting / stopping the reporting
         // All metrics added to metricsRegistry (before or after reporter was created) will be reported to Anodot
-        final AnodotReporterWrapper reporter = reporterFactory.anodot3Reporter(metricRegistry, globalProperties);
+        final AnodotReporterWrapper reporter = reporterFactory.anodot3Reporter(metricRegistry);
 
         reporter.start(); // will now start reporting
 

--- a/anodot-reporter/src/main/java/com/kenshoo/metrics/anodot/AnodotGlobalProperties.java
+++ b/anodot-reporter/src/main/java/com/kenshoo/metrics/anodot/AnodotGlobalProperties.java
@@ -1,55 +1,10 @@
 package com.kenshoo.metrics.anodot;
 
-import com.google.common.collect.ImmutableMap;
-
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.Map;
 
 /**
- * Created by tzachz on 2/22/17
+ * Created by tzachz on 4/21/17
  */
-public class AnodotGlobalProperties {
-
-    private final String hostname;
-    private final String version;
-    private final String build;
-
-    public AnodotGlobalProperties() {
-        this("unknown", "unknown");
-    }
-
-    public AnodotGlobalProperties(String version, String build) {
-        this(version, build, localMachineHostname());
-    }
-
-    public AnodotGlobalProperties(String version, String build, String hostname) {
-        this.hostname = hostname;
-        this.version = version;
-        this.build = build;
-    }
-
-    public Map<String, String> propertyMap() {
-        return ImmutableMap.of(
-                AnodotProperties.BUILD_PROPERTY, escapeDots(build),
-                AnodotProperties.VERSION_PROPERTY, escapeDots(version),
-                AnodotProperties.SERVER_PROPERTY, firstToken(hostname)
-        );
-    }
-
-    private String firstToken(String str) {
-        return str.split("\\.")[0];
-    }
-
-    private String escapeDots(String str) {
-        return str.replace(".", "_");
-    }
-
-    private static String localMachineHostname() {
-        try {
-            return InetAddress.getLocalHost().getHostName();
-        } catch (UnknownHostException e) {
-            return "not-found";
-        }
-    }
+public interface AnodotGlobalProperties {
+    Map<String, String> propertyMap();
 }

--- a/anodot-reporter/src/main/java/com/kenshoo/metrics/anodot/AnodotProperties.java
+++ b/anodot-reporter/src/main/java/com/kenshoo/metrics/anodot/AnodotProperties.java
@@ -8,7 +8,5 @@ public class AnodotProperties {
     public static final String CLASS_PROPERTY = "class";
     public static final String PACKAGE_PROPERTY = "package";
     public static final String WHAT_PROPERTY = "what";
-    public static final String VERSION_PROPERTY = "version";
-    public static final String BUILD_PROPERTY = "build";
-    public static final String SERVER_PROPERTY = "server";
+
 }

--- a/anodot-reporter/src/main/java/com/kenshoo/metrics/anodot/DefaultAnodotGlobalProperties.java
+++ b/anodot-reporter/src/main/java/com/kenshoo/metrics/anodot/DefaultAnodotGlobalProperties.java
@@ -1,0 +1,60 @@
+package com.kenshoo.metrics.anodot;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
+
+/**
+ * Created by tzachz on 2/22/17
+ */
+public class DefaultAnodotGlobalProperties implements AnodotGlobalProperties {
+
+    public static final String VERSION_PROPERTY = "version";
+    public static final String BUILD_PROPERTY = "build";
+    public static final String SERVER_PROPERTY = "server";
+
+    private final String hostname;
+    private final String version;
+    private final String build;
+
+    public DefaultAnodotGlobalProperties() {
+        this("unknown", "unknown");
+    }
+
+    public DefaultAnodotGlobalProperties(String version, String build) {
+        this(version, build, localMachineHostname());
+    }
+
+    public DefaultAnodotGlobalProperties(String version, String build, String hostname) {
+        this.hostname = hostname;
+        this.version = version;
+        this.build = build;
+    }
+
+    @Override
+    public Map<String, String> propertyMap() {
+        return ImmutableMap.of(
+                BUILD_PROPERTY, escapeDots(build),
+                VERSION_PROPERTY, escapeDots(version),
+                SERVER_PROPERTY, firstToken(hostname)
+        );
+    }
+
+    private String firstToken(String str) {
+        return str.split("\\.")[0];
+    }
+
+    private String escapeDots(String str) {
+        return str.replace(".", "_");
+    }
+
+    private static String localMachineHostname() {
+        try {
+            return InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            return "not-found";
+        }
+    }
+}

--- a/anodot-reporter/src/main/java/com/kenshoo/metrics/anodot/EmptyAnodotGlobalProperties.java
+++ b/anodot-reporter/src/main/java/com/kenshoo/metrics/anodot/EmptyAnodotGlobalProperties.java
@@ -1,0 +1,16 @@
+package com.kenshoo.metrics.anodot;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+/**
+ * Created by tzachz on 4/21/17
+ */
+public class EmptyAnodotGlobalProperties implements AnodotGlobalProperties {
+
+    @Override
+    public Map<String, String> propertyMap() {
+        return ImmutableMap.of();
+    }
+}

--- a/anodot-reporter/src/test/java/com/kenshoo/metrics/anodot/DefaultAnodotGlobalPropertiesTest.java
+++ b/anodot-reporter/src/test/java/com/kenshoo/metrics/anodot/DefaultAnodotGlobalPropertiesTest.java
@@ -4,33 +4,33 @@ import org.junit.Test;
 
 import java.util.Map;
 
-import static com.kenshoo.metrics.anodot.AnodotProperties.BUILD_PROPERTY;
-import static com.kenshoo.metrics.anodot.AnodotProperties.SERVER_PROPERTY;
-import static com.kenshoo.metrics.anodot.AnodotProperties.VERSION_PROPERTY;
+import static com.kenshoo.metrics.anodot.DefaultAnodotGlobalProperties.BUILD_PROPERTY;
+import static com.kenshoo.metrics.anodot.DefaultAnodotGlobalProperties.SERVER_PROPERTY;
+import static com.kenshoo.metrics.anodot.DefaultAnodotGlobalProperties.VERSION_PROPERTY;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 /**
  * Created by tzachz on 2/22/17
  */
-public class AnodotGlobalPropertiesTest {
+public class DefaultAnodotGlobalPropertiesTest {
 
     @Test
     public void dotsClearedFromVersionAndBuild() throws Exception {
-        final Map<String, String> properties = new AnodotGlobalProperties("v1.0.1", "1234.56").propertyMap();
+        final Map<String, String> properties = new DefaultAnodotGlobalProperties("v1.0.1", "1234.56").propertyMap();
         assertThat(properties.get(VERSION_PROPERTY), is("v1_0_1"));
         assertThat(properties.get(BUILD_PROPERTY), is("1234_56"));
     }
 
     @Test
     public void postfixesRemovedFromHostname() throws Exception {
-        final Map<String, String> properties = new AnodotGlobalProperties("1", "1", "hostname.domain.com").propertyMap();
+        final Map<String, String> properties = new DefaultAnodotGlobalProperties("1", "1", "hostname.domain.com").propertyMap();
         assertThat(properties.get(SERVER_PROPERTY), is("hostname"));
     }
 
     @Test
     public void defaultVersionAndBuildAreUnknown() throws Exception {
-        final Map<String, String> properties = new AnodotGlobalProperties().propertyMap();
+        final Map<String, String> properties = new DefaultAnodotGlobalProperties().propertyMap();
         assertThat(properties.get(VERSION_PROPERTY), is("unknown"));
         assertThat(properties.get(BUILD_PROPERTY), is("unknown"));
     }

--- a/anodot-reporter2/src/main/java/com/kenshoo/metrics/anodot/metrics2/Anodot2ReporterFactory.java
+++ b/anodot-reporter2/src/main/java/com/kenshoo/metrics/anodot/metrics2/Anodot2ReporterFactory.java
@@ -3,6 +3,7 @@ package com.kenshoo.metrics.anodot.metrics2;
 import com.kenshoo.metrics.anodot.AnodotGlobalProperties;
 import com.kenshoo.metrics.anodot.AnodotReporterConfiguration;
 import com.kenshoo.metrics.anodot.AnodotReporterWrapper;
+import com.kenshoo.metrics.anodot.EmptyAnodotGlobalProperties;
 import com.yammer.metrics.core.Anodot;
 import com.yammer.metrics.core.AnodotMetricRegistry;
 import com.yammer.metrics.core.AnodotReporter;
@@ -16,12 +17,18 @@ import java.util.concurrent.TimeUnit;
 public class Anodot2ReporterFactory {
 
     private final AnodotReporterConfiguration conf;
+    private final AnodotGlobalProperties globalProperties;
 
     public Anodot2ReporterFactory(AnodotReporterConfiguration conf) {
-        this.conf = conf;
+        this(conf, new EmptyAnodotGlobalProperties());
     }
 
-    public AnodotReporterWrapper anodot2Reporter(MetricsRegistry metricRegistry, AnodotGlobalProperties globalProperties) {
+    public Anodot2ReporterFactory(AnodotReporterConfiguration conf, AnodotGlobalProperties globalProperties) {
+        this.conf = conf;
+        this.globalProperties = globalProperties;
+    }
+
+    public AnodotReporterWrapper anodot2Reporter(MetricsRegistry metricRegistry) {
         final Anodot2MetricNameConverter converter = new Anodot2MetricNameConverter(globalProperties);
         final Anodot2RegistryFactory registryFactory = new Anodot2RegistryFactory(converter);
         final AnodotMetricRegistry anodotMetricRegistry = registryFactory.anodot2Registry(metricRegistry);

--- a/anodot-reporter2/src/test/java/com/kenshoo/metrics/anodot/metrics2/Anodot2MetricNameConverterTest.java
+++ b/anodot-reporter2/src/test/java/com/kenshoo/metrics/anodot/metrics2/Anodot2MetricNameConverterTest.java
@@ -1,10 +1,11 @@
 package com.kenshoo.metrics.anodot.metrics2;
 
-import com.kenshoo.metrics.anodot.AnodotProperties;
-import com.kenshoo.metrics.anodot.AnodotGlobalProperties;
+import com.kenshoo.metrics.anodot.DefaultAnodotGlobalProperties;
 import com.yammer.metrics.core.spec.MetricName;
 import org.junit.Test;
 
+import static com.kenshoo.metrics.anodot.AnodotProperties.*;
+import static com.kenshoo.metrics.anodot.DefaultAnodotGlobalProperties.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
@@ -16,50 +17,50 @@ public class Anodot2MetricNameConverterTest {
     private final static String VERSION = "V33";
     private final static String BUILD = "1234";
 
-    private Anodot2MetricNameConverter nameConverter = new Anodot2MetricNameConverter(new AnodotGlobalProperties(VERSION, BUILD));
+    private Anodot2MetricNameConverter nameConverter = new Anodot2MetricNameConverter(new DefaultAnodotGlobalProperties(VERSION, BUILD));
 
     @Test
     public void commonCaseParsedProperly() throws Exception {
         final MetricName anodotName = nameConverter.toAnodot2Name("com.kenshoo.MyClass.metricNameWith_Underscore.subname");
-        assertProperty(anodotName, AnodotProperties.CLASS_PROPERTY, "MyClass");
-        assertProperty(anodotName, AnodotProperties.PACKAGE_PROPERTY, "com_kenshoo");
-        assertProperty(anodotName, AnodotProperties.WHAT_PROPERTY, "metricNameWith_Underscore_subname");
+        assertProperty(anodotName, CLASS_PROPERTY, "MyClass");
+        assertProperty(anodotName, PACKAGE_PROPERTY, "com_kenshoo");
+        assertProperty(anodotName, WHAT_PROPERTY, "metricNameWith_Underscore_subname");
         assertCommonProperties(anodotName);
     }
 
     @Test
     public void noUpperCasePartsMeanNoPackageAndClass() throws Exception {
         final MetricName anodotName = nameConverter.toAnodot2Name("com.kenshoo.package.metric.subname");
-        assertProperty(anodotName, AnodotProperties.CLASS_PROPERTY, null);
-        assertProperty(anodotName, AnodotProperties.PACKAGE_PROPERTY, null);
-        assertProperty(anodotName, AnodotProperties.WHAT_PROPERTY, "com_kenshoo_package_metric_subname");
+        assertProperty(anodotName, CLASS_PROPERTY, null);
+        assertProperty(anodotName, PACKAGE_PROPERTY, null);
+        assertProperty(anodotName, WHAT_PROPERTY, "com_kenshoo_package_metric_subname");
         assertCommonProperties(anodotName);
     }
 
     @Test
     public void uppercasePackageNameMistakenForClassWhatCanYouDo() throws Exception {
         final MetricName anodotName = nameConverter.toAnodot2Name("com.kenshoo.BadlyNamedPackage.MyClass.metricName.subname");
-        assertProperty(anodotName, AnodotProperties.CLASS_PROPERTY, "BadlyNamedPackage");
-        assertProperty(anodotName, AnodotProperties.PACKAGE_PROPERTY, "com_kenshoo");
-        assertProperty(anodotName, AnodotProperties.WHAT_PROPERTY, "MyClass_metricName_subname");
+        assertProperty(anodotName, CLASS_PROPERTY, "BadlyNamedPackage");
+        assertProperty(anodotName, PACKAGE_PROPERTY, "com_kenshoo");
+        assertProperty(anodotName, WHAT_PROPERTY, "MyClass_metricName_subname");
         assertCommonProperties(anodotName);
     }
 
     @Test
     public void noPackageMetricNameFallsBackToUseEntireNameAsWhat() throws Exception {
         final MetricName anodotName = nameConverter.toAnodot2Name("MyClass.metricName.subname");
-        assertProperty(anodotName, AnodotProperties.CLASS_PROPERTY, null);
-        assertProperty(anodotName, AnodotProperties.PACKAGE_PROPERTY, null);
-        assertProperty(anodotName, AnodotProperties.WHAT_PROPERTY, "MyClass_metricName_subname");
+        assertProperty(anodotName, CLASS_PROPERTY, null);
+        assertProperty(anodotName, PACKAGE_PROPERTY, null);
+        assertProperty(anodotName, WHAT_PROPERTY, "MyClass_metricName_subname");
         assertCommonProperties(anodotName);
     }
 
     @Test
     public void digitInPackageNameAllowed() throws Exception {
         final MetricName anodotName = nameConverter.toAnodot2Name("org.apache.log4j.Appender.warn");
-        assertProperty(anodotName, AnodotProperties.CLASS_PROPERTY, "Appender");
-        assertProperty(anodotName, AnodotProperties.PACKAGE_PROPERTY, "org_apache_log4j");
-        assertProperty(anodotName, AnodotProperties.WHAT_PROPERTY, "warn");
+        assertProperty(anodotName, CLASS_PROPERTY, "Appender");
+        assertProperty(anodotName, PACKAGE_PROPERTY, "org_apache_log4j");
+        assertProperty(anodotName, WHAT_PROPERTY, "warn");
         assertCommonProperties(anodotName);
     }
 
@@ -72,9 +73,9 @@ public class Anodot2MetricNameConverterTest {
     }
 
     private void assertCommonProperties(MetricName anodotName) {
-        assertProperty(anodotName, AnodotProperties.VERSION_PROPERTY, VERSION);
-        assertProperty(anodotName, AnodotProperties.BUILD_PROPERTY, "1234");
-        assertThat(anodotName.getProperty("server"), notNullValue());
+        assertProperty(anodotName, VERSION_PROPERTY, VERSION);
+        assertProperty(anodotName, BUILD_PROPERTY, "1234");
+        assertThat(anodotName.getProperty(SERVER_PROPERTY), notNullValue());
     }
 
 }

--- a/anodot-reporter2/src/test/java/com/kenshoo/metrics/anodot/metrics2/Anodot2RegistryFactoryTest.java
+++ b/anodot-reporter2/src/test/java/com/kenshoo/metrics/anodot/metrics2/Anodot2RegistryFactoryTest.java
@@ -1,6 +1,6 @@
 package com.kenshoo.metrics.anodot.metrics2;
 
-import com.kenshoo.metrics.anodot.AnodotGlobalProperties;
+import com.kenshoo.metrics.anodot.EmptyAnodotGlobalProperties;
 import com.yammer.metrics.core.AnodotMetricRegistry;
 import com.yammer.metrics.core.MetricName;
 import com.yammer.metrics.core.MetricsRegistry;
@@ -14,7 +14,7 @@ import static org.junit.Assert.assertThat;
  */
 public class Anodot2RegistryFactoryTest {
 
-    private final Anodot2RegistryFactory factory = new Anodot2RegistryFactory(new Anodot2MetricNameConverter(new AnodotGlobalProperties()));
+    private final Anodot2RegistryFactory factory = new Anodot2RegistryFactory(new Anodot2MetricNameConverter(new EmptyAnodotGlobalProperties()));
     private final MetricsRegistry registry = new MetricsRegistry();
 
     @Test

--- a/anodot-reporter3/src/main/java/com/kenshoo/metrics/anodot/metrics3/Anodot3ReporterFactory.java
+++ b/anodot-reporter3/src/main/java/com/kenshoo/metrics/anodot/metrics3/Anodot3ReporterFactory.java
@@ -7,6 +7,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.kenshoo.metrics.anodot.AnodotGlobalProperties;
 import com.kenshoo.metrics.anodot.AnodotReporterConfiguration;
 import com.kenshoo.metrics.anodot.AnodotReporterWrapper;
+import com.kenshoo.metrics.anodot.EmptyAnodotGlobalProperties;
 
 import java.util.concurrent.TimeUnit;
 
@@ -16,12 +17,18 @@ import java.util.concurrent.TimeUnit;
 public class Anodot3ReporterFactory {
 
     private final AnodotReporterConfiguration conf;
+    private final AnodotGlobalProperties globalProperties;
 
     public Anodot3ReporterFactory(AnodotReporterConfiguration conf) {
-        this.conf = conf;
+        this(conf, new EmptyAnodotGlobalProperties());
     }
 
-    public AnodotReporterWrapper anodot3Reporter(MetricRegistry metricRegistry, AnodotGlobalProperties globalProperties) {
+    public Anodot3ReporterFactory(AnodotReporterConfiguration conf, AnodotGlobalProperties globalProperties) {
+        this.conf = conf;
+        this.globalProperties = globalProperties;
+    }
+
+    public AnodotReporterWrapper anodot3Reporter(MetricRegistry metricRegistry) {
         final Anodot3MetricNameConverter converter = new Anodot3MetricNameConverter(globalProperties);
         final Anodot3RegistryFactory registryFactory = new Anodot3RegistryFactory(converter);
         final AnodotMetricRegistry anodotMetricRegistry = registryFactory.anodot3Registry(metricRegistry);

--- a/anodot-reporter3/src/test/java/com/kenshoo/metrics/anodot/metrics3/Anodot3MetricNameConverterTest.java
+++ b/anodot-reporter3/src/test/java/com/kenshoo/metrics/anodot/metrics3/Anodot3MetricNameConverterTest.java
@@ -1,10 +1,11 @@
 package com.kenshoo.metrics.anodot.metrics3;
 
 import com.anodot.metrics.spec.MetricName;
-import com.kenshoo.metrics.anodot.AnodotProperties;
-import com.kenshoo.metrics.anodot.AnodotGlobalProperties;
+import com.kenshoo.metrics.anodot.DefaultAnodotGlobalProperties;
 import org.junit.Test;
 
+import static com.kenshoo.metrics.anodot.AnodotProperties.*;
+import static com.kenshoo.metrics.anodot.DefaultAnodotGlobalProperties.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
@@ -16,50 +17,50 @@ public class Anodot3MetricNameConverterTest {
     private final static String VERSION = "V33";
     private final static String BUILD = "1234";
 
-    private Anodot3MetricNameConverter nameConverter = new Anodot3MetricNameConverter(new AnodotGlobalProperties(VERSION, BUILD));
+    private Anodot3MetricNameConverter nameConverter = new Anodot3MetricNameConverter(new DefaultAnodotGlobalProperties(VERSION, BUILD));
 
     @Test
     public void commonCaseParsedProperly() throws Exception {
         final MetricName anodotName = nameConverter.toAnodot3Name("com.kenshoo.MyClass.metricNameWith_Underscore.subname");
-        assertProperty(anodotName, AnodotProperties.CLASS_PROPERTY, "MyClass");
-        assertProperty(anodotName, AnodotProperties.PACKAGE_PROPERTY, "com_kenshoo");
-        assertProperty(anodotName, AnodotProperties.WHAT_PROPERTY, "metricNameWith_Underscore_subname");
+        assertProperty(anodotName, CLASS_PROPERTY, "MyClass");
+        assertProperty(anodotName, PACKAGE_PROPERTY, "com_kenshoo");
+        assertProperty(anodotName, WHAT_PROPERTY, "metricNameWith_Underscore_subname");
         assertCommonProperties(anodotName);
     }
 
     @Test
     public void noUpperCasePartsMeanNoPackageAndClass() throws Exception {
         final MetricName anodotName = nameConverter.toAnodot3Name("com.kenshoo.package.metric.subname");
-        assertProperty(anodotName, AnodotProperties.CLASS_PROPERTY, null);
-        assertProperty(anodotName, AnodotProperties.PACKAGE_PROPERTY, null);
-        assertProperty(anodotName, AnodotProperties.WHAT_PROPERTY, "com_kenshoo_package_metric_subname");
+        assertProperty(anodotName, CLASS_PROPERTY, null);
+        assertProperty(anodotName, PACKAGE_PROPERTY, null);
+        assertProperty(anodotName, WHAT_PROPERTY, "com_kenshoo_package_metric_subname");
         assertCommonProperties(anodotName);
     }
 
     @Test
     public void uppercasePackageNameMistakenForClassWhatCanYouDo() throws Exception {
         final MetricName anodotName = nameConverter.toAnodot3Name("com.kenshoo.BadlyNamedPackage.MyClass.metricName.subname");
-        assertProperty(anodotName, AnodotProperties.CLASS_PROPERTY, "BadlyNamedPackage");
-        assertProperty(anodotName, AnodotProperties.PACKAGE_PROPERTY, "com_kenshoo");
-        assertProperty(anodotName, AnodotProperties.WHAT_PROPERTY, "MyClass_metricName_subname");
+        assertProperty(anodotName, CLASS_PROPERTY, "BadlyNamedPackage");
+        assertProperty(anodotName, PACKAGE_PROPERTY, "com_kenshoo");
+        assertProperty(anodotName, WHAT_PROPERTY, "MyClass_metricName_subname");
         assertCommonProperties(anodotName);
     }
 
     @Test
     public void noPackageMetricNameFallsBackToUseEntireNameAsWhat() throws Exception {
         final MetricName anodotName = nameConverter.toAnodot3Name("MyClass.metricName.subname");
-        assertProperty(anodotName, AnodotProperties.CLASS_PROPERTY, null);
-        assertProperty(anodotName, AnodotProperties.PACKAGE_PROPERTY, null);
-        assertProperty(anodotName, AnodotProperties.WHAT_PROPERTY, "MyClass_metricName_subname");
+        assertProperty(anodotName, CLASS_PROPERTY, null);
+        assertProperty(anodotName, PACKAGE_PROPERTY, null);
+        assertProperty(anodotName, WHAT_PROPERTY, "MyClass_metricName_subname");
         assertCommonProperties(anodotName);
     }
 
     @Test
     public void digitInPackageNameAllowed() throws Exception {
         final MetricName anodotName = nameConverter.toAnodot3Name("org.apache.log4j.Appender.warn");
-        assertProperty(anodotName, AnodotProperties.CLASS_PROPERTY, "Appender");
-        assertProperty(anodotName, AnodotProperties.PACKAGE_PROPERTY, "org_apache_log4j");
-        assertProperty(anodotName, AnodotProperties.WHAT_PROPERTY, "warn");
+        assertProperty(anodotName, CLASS_PROPERTY, "Appender");
+        assertProperty(anodotName, PACKAGE_PROPERTY, "org_apache_log4j");
+        assertProperty(anodotName, WHAT_PROPERTY, "warn");
         assertCommonProperties(anodotName);
     }
 
@@ -72,9 +73,9 @@ public class Anodot3MetricNameConverterTest {
     }
 
     private void assertCommonProperties(MetricName anodotName) {
-        assertProperty(anodotName, AnodotProperties.VERSION_PROPERTY, VERSION);
-        assertProperty(anodotName, AnodotProperties.BUILD_PROPERTY, "1234");
-        assertThat(anodotName.getProperty("server"), notNullValue());
+        assertProperty(anodotName, VERSION_PROPERTY, VERSION);
+        assertProperty(anodotName, BUILD_PROPERTY, "1234");
+        assertThat(anodotName.getProperty(SERVER_PROPERTY), notNullValue());
     }
 
 }

--- a/anodot-reporter3/src/test/java/com/kenshoo/metrics/anodot/metrics3/Anodot3RegistryFactoryTest.java
+++ b/anodot-reporter3/src/test/java/com/kenshoo/metrics/anodot/metrics3/Anodot3RegistryFactoryTest.java
@@ -4,7 +4,7 @@ import com.anodot.metrics.AnodotMetricRegistry;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
-import com.kenshoo.metrics.anodot.AnodotGlobalProperties;
+import com.kenshoo.metrics.anodot.EmptyAnodotGlobalProperties;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,7 +25,7 @@ public class Anodot3RegistryFactoryTest {
     private static final String NAME = "theMetric";
 
     private final MetricRegistry metricRegistry = new MetricRegistry();
-    private final Anodot3MetricNameConverter anodotMetricNameConverter = new Anodot3MetricNameConverter(new AnodotGlobalProperties());
+    private final Anodot3MetricNameConverter anodotMetricNameConverter = new Anodot3MetricNameConverter(new EmptyAnodotGlobalProperties());
 
     private final Anodot3RegistryFactory factory = new Anodot3RegistryFactory(anodotMetricNameConverter);
 


### PR DESCRIPTION
Resolves #5.
@erezlotan you're welcome to have a look - this will allow using any set of "global properties" (or none) - instead (or in addition to) the currently-mandatory version+build+server properties. 