### PR TITLE
Integration tests + fixing filter setup

### DIFF
--- a/anodot-reporter2/build.gradle
+++ b/anodot-reporter2/build.gradle
@@ -7,4 +7,5 @@ dependencies {
 
     testCompile libraries.junit
     testCompile libraries.hamcrestLibrary
+    testCompile libraries.wiremock
 }

--- a/anodot-reporter2/src/main/java/com/kenshoo/metrics/anodot/metrics2/Anodot2NonZeroFilter.java
+++ b/anodot-reporter2/src/main/java/com/kenshoo/metrics/anodot/metrics2/Anodot2NonZeroFilter.java
@@ -17,6 +17,8 @@ public class Anodot2NonZeroFilter implements AnodotMetricFilter {
             if (value instanceof Float) return (Float) value != 0;
             if (value instanceof Double) return (Double) value != 0;
             else return true;
+        } else if (metric instanceof Counter) {
+            return ((Counter)metric).count() != 0;
         } else if (metric instanceof Metered) {
             return ((Metered)metric).count() != 0;
         } else if (metric instanceof Histogram) {

--- a/anodot-reporter2/src/main/java/com/kenshoo/metrics/anodot/metrics2/Anodot2ReporterFactory.java
+++ b/anodot-reporter2/src/main/java/com/kenshoo/metrics/anodot/metrics2/Anodot2ReporterFactory.java
@@ -3,10 +3,7 @@ package com.kenshoo.metrics.anodot.metrics2;
 import com.kenshoo.metrics.anodot.AnodotGlobalProperties;
 import com.kenshoo.metrics.anodot.AnodotReporterConfiguration;
 import com.kenshoo.metrics.anodot.AnodotReporterWrapper;
-import com.yammer.metrics.core.Anodot;
-import com.yammer.metrics.core.AnodotMetricRegistry;
-import com.yammer.metrics.core.AnodotReporter;
-import com.yammer.metrics.core.MetricsRegistry;
+import com.yammer.metrics.core.*;
 
 import java.util.concurrent.TimeUnit;
 
@@ -17,10 +14,12 @@ class Anodot2ReporterFactory {
 
     private final AnodotReporterConfiguration conf;
     private final AnodotGlobalProperties globalProperties;
+    private final AnodotMetricFilter filter;
 
-    Anodot2ReporterFactory(AnodotReporterConfiguration conf, AnodotGlobalProperties globalProperties) {
+    Anodot2ReporterFactory(AnodotReporterConfiguration conf, AnodotGlobalProperties globalProperties, AnodotMetricFilter filter) {
         this.conf = conf;
         this.globalProperties = globalProperties;
+        this.filter = filter;
     }
 
     AnodotReporterWrapper anodot2Reporter(MetricsRegistry metricRegistry) {
@@ -32,7 +31,7 @@ class Anodot2ReporterFactory {
 
     private AnodotReporterWrapper anodot2Reporter(AnodotMetricRegistry anodot2Registry) {
         final AnodotReporter reporter = AnodotReporter.forRegistry(anodot2Registry)
-                .filter(new Anodot2NonZeroFilter())
+                .filter(filter)
                 .build(new Anodot(conf.getUri(), conf.getToken()));
 
         return new AnodotReporterWrapper() {

--- a/anodot-reporter2/src/test/java/com/kenshoo/metrics/anodot/metrics2/Anodot2NonZeroFilterTest.java
+++ b/anodot-reporter2/src/test/java/com/kenshoo/metrics/anodot/metrics2/Anodot2NonZeroFilterTest.java
@@ -1,5 +1,7 @@
 package com.kenshoo.metrics.anodot.metrics2;
 
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.Counter;
 import com.yammer.metrics.core.Gauge;
 import com.yammer.metrics.core.spec.MetricName;
 import org.junit.Test;
@@ -30,6 +32,13 @@ public class Anodot2NonZeroFilterTest {
         assertThat(filter.matches(METRIC_NAME, gauge(1D)), is(true));
         assertThat(filter.matches(METRIC_NAME, gauge(1L)), is(true));
         assertThat(filter.matches(METRIC_NAME, gauge("1")), is(true));
+    }
+
+    @Test
+    public void nonZeroCounterNotFilteredOut() throws Exception {
+        final Counter counter = Metrics.newCounter(this.getClass(), "counter1");
+        counter.inc();
+        assertThat(filter.matches(METRIC_NAME, counter), is(true));
     }
 
     private <T> Gauge<T> gauge(final T value) {

--- a/anodot-reporter2/src/test/java/com/kenshoo/metrics/anodot/metrics2/Anodot2ReporterBuilderTest.java
+++ b/anodot-reporter2/src/test/java/com/kenshoo/metrics/anodot/metrics2/Anodot2ReporterBuilderTest.java
@@ -1,0 +1,75 @@
+package com.kenshoo.metrics.anodot.metrics2;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.kenshoo.metrics.anodot.AnodotReporterConfiguration;
+import com.kenshoo.metrics.anodot.AnodotReporterWrapper;
+import com.kenshoo.metrics.anodot.DefaultAnodotReporterConfiguration;
+import com.yammer.metrics.Metrics;
+import com.yammer.metrics.core.AnodotMetricFilter;
+import com.yammer.metrics.core.Metric;
+import com.yammer.metrics.core.spec.MetricName;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+/**
+ * Created by tzachz on 4/24/17
+ */
+public class Anodot2ReporterBuilderTest {
+
+    private final AnodotReporterConfiguration conf = new DefaultAnodotReporterConfiguration("t", 1, "http://localhost:8080/anodot");
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(8080);
+
+    @Test
+    public void zeroesNotReportedByDefault() throws Exception {
+        Metrics.newCounter(this.getClass(), "counter3333"); // create zero counter
+        final AnodotReporterWrapper reporter = Anodot2ReporterBuilder.builderFor(conf).build(Metrics.defaultRegistry());
+        runReportCycle(reporter);
+        verify(exactly(0), postRequestedFor(urlEqualTo("/anodot?token=t")).withRequestBody(containing("counter3333")));
+    }
+
+    @Test
+    public void zeroFilterTurnedOffMeansNoFilters() throws Exception {
+        Metrics.newCounter(this.getClass(), "counter"); // create zero counter
+        final AnodotReporterWrapper reporter = Anodot2ReporterBuilder.builderFor(conf).turnZeroFilterOff().build(Metrics.defaultRegistry());
+        runReportCycle(reporter);
+        verify(postRequestedFor(urlEqualTo("/anodot?token=t")));
+    }
+
+    @Test
+    public void mustPassAllFilters() throws Exception {
+        Metrics.newCounter(this.getClass(), "counter1111").inc();
+        Metrics.newCounter(this.getClass(), "counter2222").inc();
+        Metrics.newCounter(this.getClass(), "meter1111").inc();
+
+        final AnodotReporterWrapper reporter = Anodot2ReporterBuilder.builderFor(conf)
+                .addFilter(whatPropertyContains("count")) // both counters pass this one
+                .addFilter(whatPropertyContains("1111"))  // but only the first passes this one
+                .build(Metrics.defaultRegistry());
+
+        runReportCycle(reporter);
+        verify(postRequestedFor(urlEqualTo("/anodot?token=t"))
+                .withRequestBody(containing("counter1111"))
+                .withRequestBody(notMatching(".*counter2222.*"))
+                .withRequestBody(notMatching(".*meter1111.*"))
+        );
+    }
+
+    private AnodotMetricFilter whatPropertyContains(final String substring) {
+        return new AnodotMetricFilter() {
+            @Override
+            public boolean matches(MetricName metricName, Metric metric) {
+                return metricName.getProperty("what").getValue().contains(substring);
+            }
+        };
+    }
+
+    private void runReportCycle(AnodotReporterWrapper reporter) throws InterruptedException {
+        reporter.start();
+        Thread.sleep(1300);
+        reporter.stop();
+    }
+}

--- a/anodot-reporter3/build.gradle
+++ b/anodot-reporter3/build.gradle
@@ -7,4 +7,5 @@ dependencies {
 
     testCompile libraries.junit
     testCompile libraries.hamcrestLibrary
+    testCompile libraries.wiremock
 }

--- a/anodot-reporter3/src/main/java/com/kenshoo/metrics/anodot/metrics3/Anodot3ReporterFactory.java
+++ b/anodot-reporter3/src/main/java/com/kenshoo/metrics/anodot/metrics3/Anodot3ReporterFactory.java
@@ -1,6 +1,7 @@
 package com.kenshoo.metrics.anodot.metrics3;
 
 import com.anodot.metrics.Anodot;
+import com.anodot.metrics.AnodotMetricFilter;
 import com.anodot.metrics.AnodotMetricRegistry;
 import com.anodot.metrics.AnodotReporter;
 import com.codahale.metrics.MetricRegistry;
@@ -17,10 +18,12 @@ class Anodot3ReporterFactory {
 
     private final AnodotReporterConfiguration conf;
     private final AnodotGlobalProperties globalProperties;
+    private final AnodotMetricFilter filter;
 
-    Anodot3ReporterFactory(AnodotReporterConfiguration conf, AnodotGlobalProperties globalProperties) {
+    Anodot3ReporterFactory(AnodotReporterConfiguration conf, AnodotGlobalProperties globalProperties, AnodotMetricFilter filter) {
         this.conf = conf;
         this.globalProperties = globalProperties;
+        this.filter = filter;
     }
 
     AnodotReporterWrapper anodot3Reporter(MetricRegistry metricRegistry) {
@@ -33,7 +36,7 @@ class Anodot3ReporterFactory {
     private AnodotReporterWrapper anodot3Reporter(AnodotMetricRegistry anodotRegistry) {
         final AnodotReporter reporter = AnodotReporter
                 .forRegistry(anodotRegistry)
-                .filter(new Anodot3NonZeroFilter())
+                .filter(filter)
                 .convertDurationsTo(TimeUnit.MILLISECONDS)
                 .convertRatesTo(TimeUnit.SECONDS)
                 .build(new Anodot(conf.getUri(), conf.getToken()));

--- a/anodot-reporter3/src/test/java/com/kenshoo/metrics/anodot/metrics3/Anodot3ReporterBuilderTest.java
+++ b/anodot-reporter3/src/test/java/com/kenshoo/metrics/anodot/metrics3/Anodot3ReporterBuilderTest.java
@@ -1,0 +1,78 @@
+package com.kenshoo.metrics.anodot.metrics3;
+
+import com.anodot.metrics.AnodotMetricFilter;
+import com.anodot.metrics.spec.MetricName;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.kenshoo.metrics.anodot.AnodotReporterConfiguration;
+import com.kenshoo.metrics.anodot.AnodotReporterWrapper;
+import com.kenshoo.metrics.anodot.DefaultAnodotReporterConfiguration;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+/**
+ * Created by tzachz on 4/24/17
+ */
+public class Anodot3ReporterBuilderTest {
+
+    private final AnodotReporterConfiguration conf = new DefaultAnodotReporterConfiguration("t", 1, "http://localhost:8080/anodot");
+
+    private final MetricRegistry registry = new MetricRegistry();
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(8080);
+
+    @Test
+    public void zeroesNotReportedByDefault() throws Exception {
+        registry.counter("counter"); // create zero counter
+        final AnodotReporterWrapper reporter = Anodot3ReporterBuilder.builderFor(conf).build(registry);
+        runReportCycle(reporter);
+        verify(exactly(0), postRequestedFor(urlEqualTo("/anodot?token=t")));
+    }
+
+    @Test
+    public void zeroFilterTurnedOffMeansNoFilters() throws Exception {
+        registry.counter("counter"); // create zero counter
+        final AnodotReporterWrapper reporter = Anodot3ReporterBuilder.builderFor(conf).turnZeroFilterOff().build(registry);
+        runReportCycle(reporter);
+        verify(postRequestedFor(urlEqualTo("/anodot?token=t")));
+    }
+
+    @Test
+    public void mustPassAllFilters() throws Exception {
+        registry.counter("counter1111").inc();
+        registry.counter("counter2222").inc();
+        registry.counter("meter1111").inc();
+
+        final AnodotReporterWrapper reporter = Anodot3ReporterBuilder.builderFor(conf)
+                .addFilter(whatPropertyContains("count")) // both counters pass this one
+                .addFilter(whatPropertyContains("1111"))  // but only the first passes this one
+                .build(registry);
+
+        runReportCycle(reporter);
+        verify(postRequestedFor(urlEqualTo("/anodot?token=t"))
+                .withRequestBody(containing("counter1111"))
+                .withRequestBody(notMatching(".*counter2222.*"))
+                .withRequestBody(notMatching(".*meter1111.*"))
+        );
+    }
+
+    private AnodotMetricFilter whatPropertyContains(final String substring) {
+        return new AnodotMetricFilter() {
+            @Override
+            public boolean matches(MetricName metricName, Metric metric) {
+                return metricName.getProperty("what").getValue().contains(substring);
+            }
+        };
+    }
+
+    private void runReportCycle(AnodotReporterWrapper reporter) throws InterruptedException {
+        reporter.start();
+        Thread.sleep(1500);
+        reporter.stop();
+    }
+
+}

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -18,5 +18,6 @@ project.libraries = [
         //Test libs
         junit                 : 'junit:junit-dep:4.11',
         hamcrestLibrary       : 'org.hamcrest:hamcrest-library:1.3',
+        wiremock              : 'com.github.tomakehurst:wiremock:2.6.0',
 
 ]


### PR DESCRIPTION
@erezlotan I missed a few important stuff in #8 - builder didn't pass the filters on to the reporter....

Added some integrative tests using `WireMock` to have better end-to-end coverage: using public API (Builder) and checking the data reported to Anodot.

Tests use `Thread.sleep` :pensive:, I'll fix this when I have a spare hour for some refactoring... 